### PR TITLE
Address CT Design feedback

### DIFF
--- a/src/screens/BetaHomeScreen/index.js
+++ b/src/screens/BetaHomeScreen/index.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   Dimensions,
   TouchableOpacity,
+  TouchableHighlight,
 } from 'react-native';
 
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -34,8 +35,8 @@ const moment = require('moment');
 const time = require('../../assets/time.png');
 
 import UserSection from '../components/userSection.js';
-
 import PrizeContainer from '../components/prizeContainer';
+import UserNavigationBar from '../components/userNavigationBar';
 
 import {IP_ADDRESS} from '../../constants/constants.js';
 
@@ -129,51 +130,6 @@ export default class BetaHomeScreen extends React.Component {
             {moment.unix(timeRemaining).fromNow(true)}
           </Text>
         </View>
-      </View>
-    );
-  };
-
-  renderNavigationBar = () => {
-    return (
-      <View style={styles.navigation}>
-        <View style={{width: '70%', flexDirection: 'row'}}>
-          <TouchableOpacity
-            onPress={() =>
-              this.props.navigation.navigate('GiveAwayShowScreen', {
-                navigation: this.props.navigation.navigate,
-                // FIX ME!!!
-                giveaway: 1,
-              })
-            }
-            style={{flex: 1, alignItems: 'center'}}>
-            <Icon name="home" size={30} color="#1E1E1E" />
-          </TouchableOpacity>
-          <View style={{flex: 1, alignItems: 'center'}}>
-            <TouchableOpacity
-              onPress={() =>
-                this.props.navigation.navigate('UserPaymentsScreen', {
-                  navigation: this.props.navigation.navigate,
-                  userId: 1,
-                })
-              }
-              style={{flex: 1, alignItems: 'center'}}>
-              <Icon name="credit-card" size={30} color="#1E1E1E" />
-            </TouchableOpacity>
-          </View>
-          <View style={{flex: 1, alignItems: 'center'}}>
-            <Icon name="comments" size={30} color="#1E1E1E" />
-          </View>
-        </View>
-
-        <View
-          style={{
-            marginTop: 15,
-            height: 5,
-            width: '45%',
-            backgroundColor: 'rgba(0, 0, 0, 0.05)',
-            borderRadius: 10,
-          }}
-        />
       </View>
     );
   };
@@ -318,6 +274,13 @@ export default class BetaHomeScreen extends React.Component {
     );
   };
 
+  _navigateToGiveAwayShow = giveawayId => {
+    this.props.navigation.navigate('GiveAwayShowScreen', {
+      navigation: this.props.navigation.navigate,
+      giveaway: giveawayId,
+    });
+  };
+
   render() {
     return (
       <View style={styles.container}>
@@ -341,13 +304,16 @@ export default class BetaHomeScreen extends React.Component {
         {this.state.userGiveAwayData &&
           this.state.userGiveAwayData.map((userGiveAway, key) => (
             <ScrollView style={styles.giveawayInfoContainer}>
-              <View style={{justifyContent: 'center'}}>
+              <TouchableHighlight
+                underlayColor={'transparent'}
+                onPress={() => this._navigateToGiveAwayShow(userGiveAway.id)}
+                style={{justifyContent: 'center'}}>
                 <Image
                   key={key}
                   source={this.getImage(userGiveAway.main_image.file_name)}
                   style={{width: '95%', marginTop: 10, borderRadius: 10}}
                 />
-              </View>
+              </TouchableHighlight>
               <View style={{marginLeft: 5}}>
                 {this.renderGiveAwayStats(userGiveAway)}
                 <View style={{marginTop: '5%'}}>
@@ -375,7 +341,7 @@ export default class BetaHomeScreen extends React.Component {
             height: '100%',
             justifyContent: 'flex-end',
           }}>
-          {this.renderNavigationBar()}
+          <UserNavigationBar navigation={this.props.navigation} />
         </View>
       </View>
     );
@@ -400,17 +366,5 @@ const styles = StyleSheet.create({
   },
   userInfo: {
     marginLeft: 10,
-  },
-  navigation: {
-    alignItems: 'center',
-    marginBottom: 10,
-    height: 50,
-    width: '100%',
-    borderWidth: 1,
-    borderTopColor: 'rgba(0, 0, 0, 0.05)',
-    borderLeftColor: 'white',
-    borderRightColor: 'white',
-    borderBottomColor: 'white',
-    justifyContent: 'flex-end',
   },
 });

--- a/src/screens/GiveAwayShowScreen/index.js
+++ b/src/screens/GiveAwayShowScreen/index.js
@@ -472,89 +472,99 @@ export default class GiveAwayShowScreen extends React.Component {
     const window = Dimensions.get('window');
 
     return (
-      <ScrollView onScroll={event => this.updateBackButtonLoaction(event)}>
-        {this.state.hasData && (
-          <View>
-            <Image
-              source={this.getImage(
-                this.state.data.giveaway.show_image.file_name,
-              )}
-              style={{width: '100%'}}
-            />
-
-            {/* Back button to beta home screen... */}
-            <TouchableOpacity
-              style={{
-                marginTop: 50,
-                marginLeft: 25,
-                borderRadius: 100,
-                height: 60,
-                width: 60,
-                backgroundColor: 'rgba(0, 0, 0, 0.25)',
-                zIndex: 5,
-                position: 'absolute',
-                top: this.state.backButtonScrollPosition,
-              }}
-              onPress={() => this._navigateToBetaHomeScreen()}>
-              <Icon
-                style={{marginTop: '25%', marginLeft: '25%'}}
-                name="arrow-left"
-                size={30}
-                color="#1E1E1E"
+      <View style={{flex: 1}}>
+        <ScrollView>
+          {this.state.hasData && (
+            <View>
+              <Image
+                source={this.getImage(
+                  this.state.data.giveaway.show_image.file_name,
+                )}
+                style={{width: '100%'}}
               />
-            </TouchableOpacity>
-          </View>
-        )}
-        {this.renderBlurModal()}
-        {this.state.purchaseData && this.renderPrizeView()}
-        {this.state.isPrizeDescriptionModalVisible &&
-          this.state.currentDisplayShowModalPrize &&
-          this.renderPrizeShowModal()}
 
-        {this.state.hasData && (
-          <View style={styles.contentContainer}>
-            <Text
-              style={{
-                fontWeight: 'bold',
-                marginTop: '5%',
-                fontSize: 25,
-              }}>
-              {this.state.data.giveaway.name}
-            </Text>
-            <GiveAwayStatistics giveaway={this.state.data.giveaway} />
-            <View style={{marginTop: '5%'}}>
-              <PrizeContainer
-                title="Prizes"
-                prizes={this.state.data.giveaway.prizes}
-                toggleModalFunc={this.handleTogglePrizeModal.bind(this)}
+              {/* Back button to beta home screen... */}
+              <TouchableOpacity
+                style={{
+                  marginTop: 60,
+                  marginLeft: 25,
+                  borderRadius: 100,
+                  height: 60,
+                  width: 60,
+                  backgroundColor: 'rgba(0, 0, 0, 0.25)',
+                  zIndex: 5,
+                  position: 'absolute',
+                  top: this.state.backButtonScrollPosition,
+                }}
+                onPress={() => this._navigateToBetaHomeScreen()}>
+                <Icon
+                  style={{marginTop: '25%', marginLeft: '25%'}}
+                  name="arrow-left"
+                  size={30}
+                  color="rgba(255, 255, 255, 0.5)"
+                />
+              </TouchableOpacity>
+            </View>
+          )}
+          {this.renderBlurModal()}
+          {this.state.purchaseData && this.renderPrizeView()}
+          {this.state.isPrizeDescriptionModalVisible &&
+            this.state.currentDisplayShowModalPrize &&
+            this.renderPrizeShowModal()}
+
+          {this.state.hasData && (
+            <View style={styles.contentContainer}>
+              <Text
+                style={{
+                  fontWeight: 'bold',
+                  marginTop: '5%',
+                  fontSize: 25,
+                }}>
+                {this.state.data.giveaway.name}
+              </Text>
+              <GiveAwayStatistics giveaway={this.state.data.giveaway} />
+              <View style={{marginTop: '5%'}}>
+                <PrizeContainer
+                  title="Prizes"
+                  prizes={this.state.data.giveaway.prizes}
+                  toggleModalFunc={this.handleTogglePrizeModal.bind(this)}
+                />
+              </View>
+              <View
+                style={{
+                  marginTop: '5%',
+                  height: 1,
+                  width: '95%',
+                  backgroundColor: 'rgba(0, 0, 0, 0.050)',
+                }}
+              />
+              <GiveAwayInfo
+                toggleProbabilityModalFunc={this._toggleProbabilityModal.bind(
+                  this,
+                )}
+                toggleTOSModalFunc={this._toggleTOCModal.bind(this)}
+                giveaway={this.state.data.giveaway}
               />
             </View>
-            <View
-              style={{
-                marginTop: '5%',
-                height: 1,
-                width: '95%',
-                backgroundColor: 'rgba(0, 0, 0, 0.050)',
-              }}
-            />
-            <GiveAwayInfo
-              toggleProbabilityModalFunc={this._toggleProbabilityModal.bind(
-                this,
-              )}
-              toggleTOSModalFunc={this._toggleTOCModal.bind(this)}
-              giveaway={this.state.data.giveaway}
-            />
-          </View>
-        )}
+          )}
+        </ScrollView>
         {this.state.hasData && (
           <View
             style={{
-              marginTop: 30,
-              marginBottom: '5%',
-              width: window.width - 60,
-              marginLeft: 60 / 2,
+              width: '100%',
+              marginBottom: 5,
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              borderWidth: 1,
+              paddingTop: 10,
+              borderTopColor: 'rgba(0, 0, 0, 0.05)',
+              borderLeftColor: 'white',
+              borderRightColor: 'white',
+              borderBottomColor: 'white',
+              justifyContent: 'flex-end',
             }}>
             <EcstaticButton
+              buttonWidth={'80%'}
               buttonMarginTopScalor={0}
               buttonColor={'#39f3bb'}
               isDisabled={this.state.giveawayStarted}
@@ -567,7 +577,7 @@ export default class GiveAwayShowScreen extends React.Component {
             />
           </View>
         )}
-      </ScrollView>
+      </View>
     );
   }
 }

--- a/src/screens/LoginScreen/index.js
+++ b/src/screens/LoginScreen/index.js
@@ -51,7 +51,7 @@ class LoginScreen extends React.Component {
   };
 
   _navigate = () => {
-    this.props.navigation.navigate('GiveAwayShowScreen', {
+    this.props.navigation.navigate('BetaHomeScreen', {
       navigation: this.props.navigation.navigate,
       giveawayId: this.state.giveawayId,
     });

--- a/src/screens/MainScreen/index.js
+++ b/src/screens/MainScreen/index.js
@@ -5,6 +5,7 @@ import {View, Text, Button, StyleSheet} from 'react-native';
 import IntroOnBoardScreen from '../IntroOnBoardScreen';
 import HomeScreen from '../HomeScreen';
 import GiveAwayShowScreen from '../GiveAwayShowScreen';
+import BetaHomeScreen from '../BetaHomeScreen';
 
 class MainScreen extends React.Component {
   constructor(props) {
@@ -44,15 +45,15 @@ class MainScreen extends React.Component {
 
     if (this.state.isLoggedIn && this.state.canRender) {
       return (
-        <View>
+        <View style={{flex: 1}}>
           {this.state.canRender === true && (
-            <GiveAwayShowScreen navigation={navigate} />
+            <BetaHomeScreen navigation={navigate} />
           )}
         </View>
       );
     } else {
       return (
-        <View>
+        <View style={{flex: 1}}>
           {this.state.canRender === true && (
             <IntroOnBoardScreen navigation={navigate} />
           )}

--- a/src/screens/RegistrationScreen/two.js
+++ b/src/screens/RegistrationScreen/two.js
@@ -85,7 +85,7 @@ class RegistrationScreenTwo extends React.Component {
   };
 
   _navigate = () => {
-    this.props.navigation.navigate('GiveAwayShowScreen', {
+    this.props.navigation.navigate('BetaHomeScreen', {
       navigation: this.props.navigation.navigate,
       giveawayId: this.state.giveawayId,
     });

--- a/src/screens/UserPaymentsScreen/index.js
+++ b/src/screens/UserPaymentsScreen/index.js
@@ -15,6 +15,7 @@ import UserSection from '../components/userSection.js';
 
 import UserPaymentHistoryScreen from './paymentHistory.js';
 import CreditCardForm from '../components/ccForm.js';
+import UserNavigationBar from '../components/userNavigationBar';
 
 import {IP_ADDRESS} from '../../constants/constants.js';
 
@@ -100,51 +101,6 @@ export default class UserPaymentsScreen extends React.Component {
       userSectionWidthOffset: event.nativeEvent.layout.width,
     });
   }
-
-  renderNavigationBar = () => {
-    return (
-      <View style={styles.navigation}>
-        <View style={{width: '70%', flexDirection: 'row'}}>
-          <TouchableOpacity
-            onPress={() =>
-              this.props.navigation.navigate('GiveAwayShowScreen', {
-                navigation: this.props.navigation.navigate,
-                // FIX ME!!!
-                giveaway: 1,
-              })
-            }
-            style={{flex: 1, alignItems: 'center'}}>
-            <Icon name="home" size={30} color="#1E1E1E" />
-          </TouchableOpacity>
-          <View style={{flex: 1, alignItems: 'center'}}>
-            <TouchableOpacity
-              onPress={() =>
-                this.props.navigation.navigate('UserPaymentsScreen', {
-                  navigation: this.props.navigation.navigate,
-                  userId: 1,
-                })
-              }
-              style={{flex: 1, alignItems: 'center'}}>
-              <Icon name="credit-card" size={30} color="#1E1E1E" />
-            </TouchableOpacity>
-          </View>
-          <View style={{flex: 1, alignItems: 'center'}}>
-            <Icon name="comments" size={30} color="#1E1E1E" />
-          </View>
-        </View>
-
-        <View
-          style={{
-            marginTop: 15,
-            height: 5,
-            width: '45%',
-            backgroundColor: 'rgba(0, 0, 0, 0.05)',
-            borderRadius: 10,
-          }}
-        />
-      </View>
-    );
-  };
 
   _renderDefaultCard = () => {
     return (
@@ -409,7 +365,7 @@ export default class UserPaymentsScreen extends React.Component {
             height: '100%',
             justifyContent: 'flex-end',
           }}>
-          {this.renderNavigationBar()}
+          <UserNavigationBar navigation={this.props.navigation} />
         </View>
       </View>
     );
@@ -428,18 +384,6 @@ const styles = StyleSheet.create({
     borderRightColor: 'white',
     borderTopColor: 'white',
     borderBottomColor: 'rgba(0, 0, 0, 0.05)',
-  },
-  navigation: {
-    alignItems: 'center',
-    marginBottom: 10,
-    height: 50,
-    width: '100%',
-    borderWidth: 1,
-    borderTopColor: 'rgba(0, 0, 0, 0.05)',
-    borderLeftColor: 'white',
-    borderRightColor: 'white',
-    borderBottomColor: 'white',
-    justifyContent: 'flex-end',
   },
   userInfo: {
     marginLeft: 10,

--- a/src/screens/components/ecstaticButton.js
+++ b/src/screens/components/ecstaticButton.js
@@ -13,24 +13,22 @@ export default class EcstaticButton extends React.Component {
     const {navigate} = this.props.navigation;
 
     return (
-      <View>
-        <TouchableOpacity
-          style={{
-            marginTop: this.props.buttonMarginTopScalor,
-            backgroundColor: this.props.buttonColor,
-            borderRadius: 5,
-            height: 50,
-            width: '95%',
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-          disabled={this.props.isDisabled}
-          onPress={this.props.onPressFunc}>
-          <Text style={{color: 'white', fontWeight: 'bold', fontSize: 20}}>
-            {this.props.buttonText}
-          </Text>
-        </TouchableOpacity>
-      </View>
+      <TouchableOpacity
+        style={{
+          marginTop: this.props.buttonMarginTopScalor,
+          backgroundColor: this.props.buttonColor,
+          borderRadius: 5,
+          height: 50,
+          width: this.props.buttonWidth,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+        disabled={this.props.isDisabled}
+        onPress={this.props.onPressFunc}>
+        <Text style={{color: 'white', fontWeight: 'bold', fontSize: 20}}>
+          {this.props.buttonText}
+        </Text>
+      </TouchableOpacity>
     );
   }
 }

--- a/src/screens/components/userNavigationBar.js
+++ b/src/screens/components/userNavigationBar.js
@@ -9,18 +9,21 @@ import {
   TouchableOpacity,
 } from 'react-native';
 
-// THIS COMPONENT HAS NOT BEEN ADDED. REMOVE THIS COMMENT AFTER BEING ADDED
+import Icon from 'react-native-vector-icons/FontAwesome';
+
 export default class UserNavigationBar extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
   render() {
     return (
       <View style={styles.navigation}>
         <View style={{width: '70%', flexDirection: 'row'}}>
           <TouchableOpacity
             onPress={() =>
-              this.props.navigation.navigate('GiveAwayShowScreen', {
+              this.props.navigation.navigate('BetaHomeScreen', {
                 navigation: this.props.navigation.navigate,
-                // FIX ME!!!
-                giveaway: 1,
               })
             }
             style={{flex: 1, alignItems: 'center'}}>
@@ -56,3 +59,19 @@ export default class UserNavigationBar extends React.Component {
     );
   }
 }
+
+const styles = StyleSheet.create({
+  navigation: {
+    alignItems: 'center',
+    marginBottom: 10,
+    height: 60,
+    width: '100%',
+    borderWidth: 1,
+    paddingTop: 30,
+    borderTopColor: 'rgba(0, 0, 0, 0.05)',
+    borderLeftColor: 'white',
+    borderRightColor: 'white',
+    borderBottomColor: 'white',
+    justifyContent: 'flex-end',
+  },
+});


### PR DESCRIPTION
CT and I met yesterday and asked for quick/relatively simple design fixes. This PR adds

1.) Sticky purchase button. 
2.) Static back home btn
3.) Makes use of the `UserNavigationBar` component to modularize code.
4.) Fixes padding on navigation bar
5.) Navigation Changes:
- App now opens on `BetaHomeScreen` instead of `GiveAwayShowScreen` if logged in 
- GiveAway image on `BetaHomeScreen` now navigates to `GiveAwayShowScreen`
- home icon now goes to `BetaHomeScreen` and not `GiveAwayShowScreen`

Sticky purchase button:
<img width="455" alt="Screen Shot 2019-11-03 at 5 28 24 PM" src="https://user-images.githubusercontent.com/21197425/68093101-0ecad480-fe60-11e9-92e4-fdcfba90a97e.png">

Static back home btn:
<img width="515" alt="Screen Shot 2019-11-03 at 5 28 30 PM" src="https://user-images.githubusercontent.com/21197425/68093106-1d18f080-fe60-11e9-85bd-59295d4b6056.png">

Fixes padding on navigation bar:
<img width="510" alt="Screen Shot 2019-11-03 at 5 28 08 PM" src="https://user-images.githubusercontent.com/21197425/68093115-30c45700-fe60-11e9-8854-53ca4dc68a0a.png">



 